### PR TITLE
fix: pg_isready healthcheck uses correct user to silence FATAL logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
       - ./postgres/seed.sql:/docker-entrypoint-initdb.d/02-seed.sql:ro
     healthcheck:
       # Najprostszy check - czy postgres odpowiada na porcie 5432
-      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -p 5432"]
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -p 5432 -U ${POSTGRES_USER:-cordis}"]
       interval: 10s
       timeout: 5s
       retries: 15


### PR DESCRIPTION
Add -U flag to pg_isready so it connects as the cordis user instead of the container's root user (which doesn't exist in PostgreSQL).