### PR TITLE
feat: fix Cordyn Apps public bots in Tauri desktop + bump to v0.1.202

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Cordyn",
-  "version": "0.1.201",
+  "version": "0.1.202",
   "identifier": "com.cordis.cordyn",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 ﻿import React, { useState, useEffect, useLayoutEffect, useRef, useMemo } from 'react';
 import ReactDOM from 'react-dom';
-import { TitleBar, isTauri } from './TitleBar';
+import { TitleBar, isTauri, openExternalLink } from './TitleBar';
 import ImageCropModal, { type CropShape } from './ImageCropModal';
 import { translate, resolveLocale, bcp47 as localeBcp47, loadLocale, detectLocale, LOCALES, type Locale, type TimeFormat } from './i18n';
 import { motion, AnimatePresence } from 'motion/react';
@@ -14450,14 +14450,12 @@ export default function App() {
                   <h2 className="font-bold text-white text-base">Cordyn Apps</h2>
                   <p className="text-xs text-zinc-500">Rozszerzenia i boty dla serwera <span className="text-zinc-300">{serverFull?.name}</span></p>
                 </div>
-                <a
-                  href="/apps"
-                  target="_blank"
-                  rel="noopener noreferrer"
+                <button
+                  onClick={() => openExternalLink(STATIC_BASE ? `${STATIC_BASE}/apps` : '/apps')}
                   className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-medium text-violet-400 hover:text-violet-300 border border-violet-500/25 hover:bg-violet-500/10 transition-all shrink-0 mr-1"
                 >
                   <ExternalLink size={11}/> Biblioteka
-                </a>
+                </button>
                 <button onClick={()=>setAppsModalOpen(false)} className="w-8 h-8 flex items-center justify-center rounded-xl text-zinc-500 hover:text-zinc-200 hover:bg-white/[0.07] transition-all">
                   <X size={16}/>
                 </button>
@@ -14484,9 +14482,9 @@ export default function App() {
                         <Globe size={22} className="text-zinc-600"/>
                       </div>
                       <p className="text-zinc-500 text-sm">Brak publicznych aplikacji od społeczności</p>
-                      <a href="/apps" target="_blank" rel="noopener noreferrer" className="text-xs text-violet-400 hover:text-violet-300 transition-colors flex items-center gap-1">
+                      <button onClick={() => openExternalLink(STATIC_BASE ? `${STATIC_BASE}/apps` : '/apps')} className="text-xs text-violet-400 hover:text-violet-300 transition-colors flex items-center gap-1">
                         <ExternalLink size={11}/> Otwórz Cordyn Apps →
-                      </a>
+                      </button>
                     </div>
                   ) : publicApps.map(app => {
                     const alreadyIn = installedBots.some(b => b.bot_id === app.bot_user_id);

--- a/src/TitleBar.tsx
+++ b/src/TitleBar.tsx
@@ -90,3 +90,18 @@ export function TitleBar() {
 // @tauri-apps/api on web builds (dynamic import keeps it tree-shaken).
 export const isTauri =
   typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+
+/**
+ * Open a URL in the system browser.
+ * In Tauri: uses @tauri-apps/plugin-shell so the OS browser opens the link.
+ * On web: uses window.open with _blank.
+ */
+export function openExternalLink(url: string): void {
+  if (isTauri) {
+    import('@tauri-apps/plugin-shell').then(({ open }) => open(url)).catch(() => {
+      window.open(url, '_blank', 'noopener,noreferrer');
+    });
+  } else {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  }
+}

--- a/src/developer/developerApi.ts
+++ b/src/developer/developerApi.ts
@@ -1,4 +1,8 @@
-const BASE = '/api/developer';
+import { API_BASE } from '../api';
+
+// Strip trailing /api to get the root API base, then re-add /api/developer
+// so this works in web (relative /api) AND Tauri desktop (absolute URL).
+const BASE = `${API_BASE}/developer`;
 
 async function req<T>(method: string, path: string, body?: any): Promise<T> {
   const token =
@@ -100,16 +104,16 @@ export const devApi = {
 
   // Bot invite helpers (used by DeveloperPortal + AppsMarketplace)
   getMyServers: () =>
-    req<MyServer[]>('GET', '/api/oauth2/bot-invite/my-servers'),
+    req<MyServer[]>('GET', `${API_BASE}/oauth2/bot-invite/my-servers`),
   addBotToServer: (clientId: string, serverId: string) =>
-    req<{ success: boolean }>('POST', '/api/oauth2/bot-invite/confirm', {
+    req<{ success: boolean }>('POST', `${API_BASE}/oauth2/bot-invite/confirm`, {
       client_id: clientId,
       server_id: serverId,
     }),
 };
 
 export const appsApi = {
-  list: () => req<PublicApp[]>('GET', '/api/apps'),
-  search: (q: string) => req<PublicApp[]>('GET', `/api/apps/search?q=${encodeURIComponent(q)}`),
-  get: (clientId: string) => req<PublicApp>('GET', `/api/apps/${clientId}`),
+  list: () => req<PublicApp[]>('GET', `${API_BASE}/apps`),
+  search: (q: string) => req<PublicApp[]>('GET', `${API_BASE}/apps/search?q=${encodeURIComponent(q)}`),
+  get: (clientId: string) => req<PublicApp>('GET', `${API_BASE}/apps/${clientId}`),
 };


### PR DESCRIPTION
- developerApi.ts: use API_BASE from api.ts instead of hardcoded /api paths so all API calls work in Tauri desktop (absolute URL) and web (relative)
- TitleBar.tsx: add openExternalLink() helper — uses tauri-plugin-shell to open URLs in the system browser when running as desktop app
- App.tsx: replace <a href="/apps"> Biblioteka links with openExternalLink() so desktop app opens the marketplace page correctly
- tauri.conf.json: bump version to 0.1.202